### PR TITLE
Update TaxDayEndingEvent.cs

### DIFF
--- a/Modules/Taxes/Events/TaxDayEndingEvent.cs
+++ b/Modules/Taxes/Events/TaxDayEndingEvent.cs
@@ -253,7 +253,7 @@ internal sealed class TaxDayEndingEvent : DayEndingEvent
         int withheld;
         if (dayIncome >= debtOutstanding)
         {
-            withheld = dayIncome - debtOutstanding;
+            withheld = debtOutstanding;
             debtOutstanding = 0;
             Log.I(
                 $"[TXS]: {taxpayer.Name} has successfully paid off their outstanding debt and will resume earning income from Shipping Bin sales.");


### PR DESCRIPTION
If being able to clear oustanding debt in one go, it witheld all your income minus outstanding debt instead of just the oustanding debt.